### PR TITLE
feat: add advanced settings to all three tools

### DIFF
--- a/constants/env.ts
+++ b/constants/env.ts
@@ -7,6 +7,13 @@ export const WIDGET_HEIGHT_GENERATE_IMAGE = 575;
 export const WIDGET_HEIGHT_UPSCALE_WITH_KEY = 340;
 export const WIDGET_HEIGHT_UPSCALE_WITHOUT_KEY = 480;
 
+// Heights requested while an advanced-settings panel is open. The window grows
+// so the extra controls fit; if the screen cannot accommodate the request,
+// Figma clamps it and .scrollable-content scrolls instead.
+export const WIDGET_HEIGHT_REMOVE_BG_ADVANCED = 690;
+export const WIDGET_HEIGHT_UPSCALE_ADVANCED = 410;
+export const WIDGET_HEIGHT_GENERATE_IMAGE_ADVANCED = 710;
+
 export default {
     API_KEY_NAME,
     WIDGET_WIDTH,
@@ -15,5 +22,8 @@ export default {
     WIDGET_HEIGHT_ACCOUNT_PAGE,
     WIDGET_HEIGHT_GENERATE_IMAGE,
     WIDGET_HEIGHT_UPSCALE_WITH_KEY,
-    WIDGET_HEIGHT_UPSCALE_WITHOUT_KEY
+    WIDGET_HEIGHT_UPSCALE_WITHOUT_KEY,
+    WIDGET_HEIGHT_REMOVE_BG_ADVANCED,
+    WIDGET_HEIGHT_UPSCALE_ADVANCED,
+    WIDGET_HEIGHT_GENERATE_IMAGE_ADVANCED
 }

--- a/constants/generateImageOptions.ts
+++ b/constants/generateImageOptions.ts
@@ -56,4 +56,54 @@ export const PRESET_TAGS = [
 export const DEFAULT_STYLE = "Pop Art" as const;
 export const DEFAULT_ASPECT_RATIO = "Square" as const;
 export const DEFAULT_NEGATIVE_PROMPT = "" as const;
-export const DEFAULT_IMAGE_COUNT = 2 as const; 
+export const DEFAULT_IMAGE_COUNT = 2 as const;
+
+// A labeled option for a <select> where the displayed text differs from the
+// value sent to the API. Shared by the advanced-settings option lists.
+export interface SelectOption {
+  label: string;
+  value: string;
+}
+
+export const IMAGE_COUNT_OPTIONS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] as const;
+
+export const TEXT2IMAGE_MODEL_OPTIONS: SelectOption[] = [
+  { label: "Default", value: "" },
+  { label: "Flux Kontext Max", value: "urn:air:sdxl:model:fluxai:flux_kontext_max@1" },
+  { label: "Flux Kontext Pro", value: "urn:air:sdxl:model:fluxai:flux_kontext_pro@1" },
+  { label: "Flux 2 Flex", value: "urn:air:fluxai:model:fluxai:flux-2-flex@1" },
+  { label: "Flux 2 Pro", value: "urn:air:fluxai:model:fluxai:flux-2-pro@1" },
+  { label: "Flux 2 Max", value: "urn:air:fluxai:model:fluxai:flux-2-max@1" },
+  { label: "Flux 2 Pro (Preview)", value: "urn:air:fluxai:model:fluxai:flux-2-pro-preview@1" },
+  { label: "DALL·E 3", value: "urn:air:openai:model:openai:dall-e-3@1" },
+  { label: "GPT Image 1", value: "urn:air:openai:model:openai:gpt-image-1@1" },
+  { label: "GPT Image 1.5", value: "urn:air:openai:model:openai:gpt-image-1.5@1" },
+  { label: "Gemini 2.5 Flash Image", value: "urn:air:google:model:google:gemini-2.5-flash-image@1" },
+  { label: "Gemini 3 Pro Image", value: "urn:air:google:model:google:gemini-3-pro-image@1" },
+  { label: "Gemini 3.1 Flash Image", value: "urn:air:google:model:google:gemini-3.1-flash-image@1" },
+  { label: "Seedream 4.0", value: "urn:air:seedream:model:seedream:seedream@4.0" },
+  { label: "Seedream 4.5", value: "urn:air:seedream:model:seedream:seedream@4.5" },
+  { label: "Seedream 5.0 Lite", value: "urn:air:seedream:model:seedream:seedream@5.0-lite" },
+  { label: "Imagen 4.0", value: "urn:air:google:model:google:imagen-4.0-generate-001@1" },
+  { label: "Imagen 4.0 Ultra", value: "urn:air:google:model:google:imagen-4.0-ultra-generate-001@1" },
+  { label: "Imagen 4.0 Fast", value: "urn:air:google:model:google:imagen-4.0-fast-generate-001@1" },
+  { label: "Ideogram 1", value: "urn:air:ideogram:model:ideogram:ideogram@1" },
+  { label: "Ideogram 2", value: "urn:air:ideogram:model:ideogram:ideogram@2" },
+  { label: "Ideogram Turbo 1", value: "urn:air:ideogram:model:ideogram:ideogram-turbo@1" },
+  { label: "Ideogram Turbo 2", value: "urn:air:ideogram:model:ideogram:ideogram-turbo@2" },
+  { label: "Ideogram 2a", value: "urn:air:ideogram:model:ideogram:ideogram-2a@1" },
+  { label: "Ideogram 2a Turbo", value: "urn:air:ideogram:model:ideogram:ideogram-2a-turbo@1" },
+  { label: "Ideogram 3", value: "urn:air:ideogram:model:ideogram:ideogram@3" },
+  { label: "Qwen Image 2.5", value: "urn:air:qwen:model:qwen:qwen-image-2.5@1" },
+  { label: "Reve", value: "urn:air:reve:model:reve:reve@1" },
+  { label: "Hunyuan Image 3", value: "urn:air:hunyuan:model:hunyuan:hunyuan-image@3" },
+  { label: "Runway Gen-4 Image Ref", value: "urn:air:runway:model:runway:gen4-image-ref@1" },
+  { label: "Kling V1.5", value: "urn:air:kling:model:kling:kling-v1-5@1" },
+  { label: "Kling V2", value: "urn:air:kling:model:kling:kling-v2@1" },
+  { label: "Kling V2.1", value: "urn:air:kling:model:kling:kling-v2-1@1" },
+  { label: "Kling V3", value: "urn:air:kling:model:kling:kling-v3@1" },
+  { label: "Kling V3 Omni", value: "urn:air:kling:model:kling:kling-v3-omni@1" },
+  { label: "Kling Image O1", value: "urn:air:kling:model:kling:kling-image-o1@1" },
+];
+
+export const DEFAULT_TEXT2IMAGE_MODEL = "" as const;

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -2,6 +2,8 @@ export * from './commands';
 export * from './env';
 export * from './errorMessages';
 export * from './generateImageOptions';
+export * from './removeBgOptions';
+export * from './upscaleOptions';
 export * from './messages';
 export * from './promptExamples';
 export * from './routes';

--- a/constants/removeBgOptions.ts
+++ b/constants/removeBgOptions.ts
@@ -1,0 +1,67 @@
+import { SelectOption } from "./generateImageOptions";
+
+// Advanced-settings option lists for the Remove Background feature.
+// Values are what the Picsart removebg API expects; labels are shown in the UI.
+
+// cutout returns the subject as a sticker; mask returns a black/white matte.
+export const REMOVEBG_OUTPUT_TYPE_CUTOUT = "cutout" as const;
+export const REMOVEBG_OUTPUT_TYPE_OPTIONS: SelectOption[] = [
+  { label: "Cutout", value: REMOVEBG_OUTPUT_TYPE_CUTOUT },
+  { label: "Mask", value: "mask" },
+];
+export const DEFAULT_REMOVEBG_OUTPUT_TYPE = REMOVEBG_OUTPUT_TYPE_CUTOUT;
+
+// Output image format. The API also offers WEBP, but figma.createImage() only
+// decodes PNG/JPG/GIF, so a WEBP result could not be placed on the canvas.
+// PNG is the API default and the only format that keeps the cutout transparent.
+export const REMOVEBG_FORMAT_OPTIONS = ["PNG", "JPG"] as const;
+export const DEFAULT_REMOVEBG_FORMAT = "PNG" as const;
+
+// How the subject is scaled onto the background.
+export const REMOVEBG_SCALE_OPTIONS: SelectOption[] = [
+  { label: "Fit", value: "fit" },
+  { label: "Fill", value: "fill" },
+];
+export const DEFAULT_REMOVEBG_SCALE = "fit" as const;
+
+// Segmentation models the API accepts. "" sends no model field, leaving the
+// choice to the API — the behaviour the plugin had before advanced settings.
+export const REMOVEBG_MODEL_OPTIONS: SelectOption[] = [
+  { label: "Default", value: "" },
+  { label: "SOD 8.2", value: "urn:air:picsart:model:picsart:sod@8.2" },
+  { label: "SOD 10", value: "urn:air:picsart:model:picsart:sod@10" },
+  { label: "SOD 10.1", value: "urn:air:picsart:model:picsart:sod@10.1" },
+  { label: "SOD 11", value: "urn:air:picsart:model:picsart:sod@11" },
+];
+export const DEFAULT_REMOVEBG_MODEL = "" as const;
+
+// Drop-shadow configuration. "disabled" renders no shadow; "custom" uses the
+// shadow_offset_x / shadow_offset_y values; the rest are preset directions.
+export const REMOVEBG_SHADOW_DISABLED = "disabled" as const;
+export const REMOVEBG_SHADOW_CUSTOM = "custom" as const;
+export const REMOVEBG_SHADOW_OPTIONS: SelectOption[] = [
+  { label: "Disabled", value: REMOVEBG_SHADOW_DISABLED },
+  { label: "Custom", value: REMOVEBG_SHADOW_CUSTOM },
+  { label: "Bottom", value: "bottom" },
+  { label: "Bottom right", value: "bottom-right" },
+  { label: "Bottom left", value: "bottom-left" },
+  { label: "Right", value: "right" },
+  { label: "Left", value: "left" },
+  { label: "Top", value: "top" },
+  { label: "Top right", value: "top-right" },
+  { label: "Top left", value: "top-left" },
+];
+export const DEFAULT_REMOVEBG_SHADOW = REMOVEBG_SHADOW_DISABLED;
+
+// Numeric defaults and ranges, matching the API.
+export const DEFAULT_REMOVEBG_BG_BLUR = 0 as const;
+export const DEFAULT_REMOVEBG_STROKE_SIZE = 0 as const;
+export const DEFAULT_REMOVEBG_STROKE_COLOR = "FFFFFF" as const;
+export const DEFAULT_REMOVEBG_STROKE_OPACITY = 100 as const;
+export const DEFAULT_REMOVEBG_SHADOW_OPACITY = 20 as const;
+export const DEFAULT_REMOVEBG_SHADOW_BLUR = 50 as const;
+export const DEFAULT_REMOVEBG_SHADOW_OFFSET = 0 as const;
+export const REMOVEBG_PERCENT_MIN = 0 as const;
+export const REMOVEBG_PERCENT_MAX = 100 as const;
+export const REMOVEBG_OFFSET_MIN = -100 as const;
+export const REMOVEBG_OFFSET_MAX = 100 as const;

--- a/constants/types.ts
+++ b/constants/types.ts
@@ -15,6 +15,7 @@ export const TYPE_GENERATED_IMAGES = "generated-images" as const;
 export const TYPE_SWITCH_TAB = "switch-tab" as const;
 export const TYPE_SET_BALANCE = "set-balance" as const;
 export const TYPE_GET_BALANCE = "get-balance" as const;
+export const TYPE_RESIZE = "resize" as const;
 
 const TYPES = {
   TYPE_IMAGEBYTES,
@@ -33,6 +34,7 @@ const TYPES = {
   TYPE_SWITCH_TAB,
   TYPE_SET_BALANCE,
   TYPE_GET_BALANCE,
+  TYPE_RESIZE,
 };
 
 export default TYPES;

--- a/constants/upscaleOptions.ts
+++ b/constants/upscaleOptions.ts
@@ -1,0 +1,7 @@
+// Advanced-settings option lists for the Upscale (enhance) feature.
+
+// Output image format. The API also offers WEBP, but figma.createImage() only
+// decodes PNG/JPG/GIF, so a WEBP result could not be placed on the canvas.
+// JPG is the API default; PNG keeps transparency at the cost of file size.
+export const UPSCALE_FORMAT_OPTIONS = ["JPG", "PNG"] as const;
+export const DEFAULT_UPSCALE_FORMAT = "JPG" as const;

--- a/controllers/EnhanceController.ts
+++ b/controllers/EnhanceController.ts
@@ -5,6 +5,8 @@ import {
   TYPE_TAB,
   TAB_UPSCALE,
   TYPE_GET_BALANCE,
+  WIDGET_HEIGHT_UPSCALE_WITH_KEY,
+  WIDGET_HEIGHT_UPSCALE_WITHOUT_KEY,
 } from "@constants/index";
 import CustomSessionStorage from "@services/CustomSessionStorage";
 import { sendImageSelectionStatus } from "@services/ImageProcessor";
@@ -16,7 +18,9 @@ const EnhanceController = async () => {
   figma.showUI(__html__, {
     visible: true,
     themeColors: true,
-    height: apiKey ? 340 : 480,
+    // The Upscale tab restores this height when its advanced panel closes, so
+    // the two must stay in step — hence the shared constants.
+    height: apiKey ? WIDGET_HEIGHT_UPSCALE_WITH_KEY : WIDGET_HEIGHT_UPSCALE_WITHOUT_KEY,
   });
 
   setTimeout(async () => {

--- a/services/MessageListeners.ts
+++ b/services/MessageListeners.ts
@@ -27,6 +27,8 @@ import {
   WIDGET_HEIGHT_UPSCALE_WITHOUT_KEY,
   TYPE_SET_BALANCE,
   TYPE_GET_BALANCE,
+  TYPE_RESIZE,
+  WIDGET_WIDTH,
 } from "@constants/index";
 import { getBalance } from "@api/index";
 
@@ -92,6 +94,21 @@ export const setMessageListeners = (figma : PluginAPI) => {
     // report was dropped in silence.
     if (response.type === TYPE_NOTIFY) {
       figma.notify(response.msg, { error: !response.success });
+      return;
+    }
+
+    // Only the sandbox can change the window size, so the UI asks for one when
+    // an advanced-settings panel opens or closes. Resizing a hidden UI throws,
+    // hence the guard.
+    if (response.type === TYPE_RESIZE) {
+      const height = Number(response.height);
+      if (Number.isFinite(height) && height > 0) {
+        try {
+          figma.ui.resize(WIDGET_WIDTH, Math.round(height));
+        } catch (error) {
+          console.error("Failed to resize plugin window:", error);
+        }
+      }
       return;
     }
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,4 +1,4 @@
-import { TOKEN_ERR, BALANACE, HEADERAPI, PICSARTURL, GENAIURL, UPSCALE, GENERATEIMAGE, KEY_WRONG_ERR, REMOVEBG } from "@constants/index";
+import { TOKEN_ERR, BALANACE, HEADERAPI, PICSARTURL, GENAIURL, UPSCALE, GENERATEIMAGE, KEY_WRONG_ERR, REMOVEBG, REMOVEBG_SHADOW_DISABLED, REMOVEBG_SHADOW_CUSTOM } from "@constants/index";
 import getImageBinary from "@utils/imageprocessor";
 import { customFetch } from "./customFetch";
 
@@ -31,6 +31,28 @@ interface GenerateImageOptions {
     style: string;
     negative_prompt?: string;
     count?: number;
+    model?: string;
+}
+
+// Advanced removebg parameters. Every field is optional and only sent when set,
+// so a request built from the UI defaults matches the one this plugin sent
+// before advanced settings existed.
+interface RemoveBackgroundOptions {
+    output_type?: string;
+    format?: string;
+    model?: string;
+    bg_color?: string;
+    bg_blur?: number;
+    scale?: string;
+    auto_center?: boolean;
+    stroke_size?: number;
+    stroke_color?: string;
+    stroke_opacity?: number;
+    shadow?: string;
+    shadow_opacity?: number;
+    shadow_blur?: number;
+    shadow_offset_x?: number;
+    shadow_offset_y?: number;
 }
 
 // The GenAI API reports lowercase statuses ("processing", "success") while an
@@ -108,6 +130,9 @@ export const generateImage = async (prompt: string, key: string, options: Genera
                 height: options.height,
                 count: options.count || 1,
                 style: options.style,
+                // Omitted rather than sent empty, so the API applies its own
+                // default model when the user has not picked one.
+                ...(options.model ? { model: options.model } : {}),
             }),
         })
         // Extract credits from response header
@@ -212,13 +237,38 @@ export const downloadGeneratedImage = async (imageUrl: string) => {
     }
 };
 
-export const removeBackgroundApi = async (imageBytes: Uint8Array, key: string) => {
+export const removeBackgroundApi = async (imageBytes: Uint8Array, key: string, options: RemoveBackgroundOptions = {}) => {
     try {
         const imageBinary = await getImageBinary(imageBytes.buffer as ArrayBuffer);
 
         const formData = new FormData();
         formData.append("size", "auto");
         formData.append("image", imageBinary);
+
+        if (options.output_type) formData.append("output_type", options.output_type);
+        if (options.format) formData.append("format", options.format);
+        if (options.model) formData.append("model", options.model);
+        if (options.scale) formData.append("scale", options.scale);
+        if (options.auto_center) formData.append("auto_center", "true");
+        if (options.bg_color) formData.append("bg_color", options.bg_color);
+        if (options.bg_blur) formData.append("bg_blur", String(options.bg_blur));
+        // The colour and opacity only mean something once a stroke has width,
+        // so they ride along with stroke_size instead of being sent on their own.
+        if (options.stroke_size) {
+            formData.append("stroke_size", String(options.stroke_size));
+            if (options.stroke_color) formData.append("stroke_color", options.stroke_color);
+            if (options.stroke_opacity !== undefined) formData.append("stroke_opacity", String(options.stroke_opacity));
+        }
+        if (options.shadow && options.shadow !== REMOVEBG_SHADOW_DISABLED) {
+            formData.append("shadow", options.shadow);
+            if (options.shadow_opacity !== undefined) formData.append("shadow_opacity", String(options.shadow_opacity));
+            if (options.shadow_blur !== undefined) formData.append("shadow_blur", String(options.shadow_blur));
+            // Offsets are read only by the "custom" direction.
+            if (options.shadow === REMOVEBG_SHADOW_CUSTOM) {
+                if (options.shadow_offset_x !== undefined) formData.append("shadow_offset_x", String(options.shadow_offset_x));
+                if (options.shadow_offset_y !== undefined) formData.append("shadow_offset_y", String(options.shadow_offset_y));
+            }
+        }
 
         const response = await customFetch(PICSARTURL + REMOVEBG, {
             method: "POST",
@@ -252,7 +302,7 @@ export const removeBackgroundApi = async (imageBytes: Uint8Array, key: string) =
     }
 };
 
-export const enhanceImage = async (imageBytes: Uint8Array, key: string, scaleFactor: number) => {
+export const enhanceImage = async (imageBytes: Uint8Array, key: string, scaleFactor: number, format?: string) => {
     try {
         const imageBinary = await getImageBinary(imageBytes.buffer as ArrayBuffer);
 
@@ -260,6 +310,7 @@ export const enhanceImage = async (imageBytes: Uint8Array, key: string, scaleFac
         formData.append("size", "auto");
         formData.append("image", imageBinary);
         formData.append('upscale_factor', scaleFactor.toString());
+        if (format) formData.append("format", format);
 
         const response = await customFetch(PICSARTURL + UPSCALE, {
             method: "POST",

--- a/src/components/generateImage/GenerateImage.tsx
+++ b/src/components/generateImage/GenerateImage.tsx
@@ -13,10 +13,16 @@ import {
   DEFAULT_ASPECT_RATIO,
   DEFAULT_NEGATIVE_PROMPT,
   DEFAULT_IMAGE_COUNT,
+  IMAGE_COUNT_OPTIONS,
+  TEXT2IMAGE_MODEL_OPTIONS,
+  DEFAULT_TEXT2IMAGE_MODEL,
+  WIDGET_HEIGHT_GENERATE_IMAGE,
+  WIDGET_HEIGHT_GENERATE_IMAGE_ADVANCED,
   getNextPromptExample,
   TYPE_SET_BALANCE,
 } from "@constants/index";
 import { Button, LoadingSpinner } from "@components/index";
+import usePluginHeight from "@hooks/usePluginHeight";
 import { BtnType } from "../../types/enums";
 import "./styles.scss";
 
@@ -38,9 +44,18 @@ const GenerateImage: React.FC<GenerateImageProps> = ({
   const [showAdvancedOptions, setShowAdvancedOptions] = useState<boolean>(false);
   const [aspectRatio, setAspectRatio] = useState<string>(DEFAULT_ASPECT_RATIO);
   const [style, setStyle] = useState<string>(DEFAULT_STYLE);
+  const [count, setCount] = useState<number>(DEFAULT_IMAGE_COUNT);
+  const [model, setModel] = useState<string>(DEFAULT_TEXT2IMAGE_MODEL);
   const [currentPromptIndex, setCurrentPromptIndex] = useState<number>(-1);
   const [showInfoTooltip, setShowInfoTooltip] = useState<boolean>(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // The expanded prompt hides the advanced panel, so it needs no extra room.
+  usePluginHeight(
+    showAdvancedSettings && !isFullscreen
+      ? WIDGET_HEIGHT_GENERATE_IMAGE_ADVANCED
+      : WIDGET_HEIGHT_GENERATE_IMAGE
+  );
 
   // Handle delayed appearance of advanced options
   useEffect(() => {
@@ -123,12 +138,13 @@ const GenerateImage: React.FC<GenerateImageProps> = ({
         }
       }
       
-      const response = await generateImage(finalPrompt, gottenKey, { 
+      const response = await generateImage(finalPrompt, gottenKey, {
         width: dimensions.width,
         height: dimensions.height,
         style,
         negative_prompt: DEFAULT_NEGATIVE_PROMPT,
-        count: DEFAULT_IMAGE_COUNT
+        count,
+        model,
       });
       
       if (response.success && response.inferenceId) {
@@ -362,19 +378,51 @@ const GenerateImage: React.FC<GenerateImageProps> = ({
                     ))}
                   </select>
                 </div>
+
+                <div className="option-group">
+                  <label className="option-label">Model</label>
+                  <select
+                    className="option-select"
+                    value={model}
+                    onChange={(e) => setModel(e.target.value)}
+                    tabIndex={18}
+                  >
+                    {TEXT2IMAGE_MODEL_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div className="option-group">
+                  <label className="option-label">Number of images</label>
+                  <select
+                    className="option-select"
+                    value={count}
+                    onChange={(e) => setCount(Number(e.target.value))}
+                    tabIndex={19}
+                  >
+                    {IMAGE_COUNT_OPTIONS.map((option) => (
+                      <option key={option} value={option}>
+                        {option}
+                      </option>
+                    ))}
+                  </select>
+                </div>
               </div>
             )}
           </div>
 
-          <Button type={btnType} cb={cb} tabIndex={18} />
-          
+          <Button type={btnType} cb={cb} tabIndex={20} />
+
           {loading && <LoadingSpinner />}
         </>
       )}
 
       {isFullscreen && (
         <div style={{ paddingTop: '12px' }}>
-          <Button type={btnType} cb={cb} tabIndex={18} />
+          <Button type={btnType} cb={cb} tabIndex={20} />
           {loading && <LoadingSpinner />}
         </div>
       )}

--- a/src/components/generateImage/styles.scss
+++ b/src/components/generateImage/styles.scss
@@ -400,10 +400,11 @@
   overflow: hidden;
   transition: all 0.3s ease; /* Smooth transition without delay since delay is handled in JS */
   
-  /* When visible, show with animation */
+  /* When visible, show with animation. The cap only bounds the reveal
+     animation, so it has to clear the tallest panel (four controls). */
   &.visible {
     opacity: 1;
-    max-height: 200px;
+    max-height: 400px;
   }
 }
 

--- a/src/components/removeBackground/RemoveBackground.tsx
+++ b/src/components/removeBackground/RemoveBackground.tsx
@@ -7,13 +7,42 @@ import {
   TYPE_IMAGEBYTES,
   TYPE_NOTIFY,
   TYPE_SET_BALANCE,
+  SelectOption,
+  REMOVEBG_MODEL_OPTIONS,
+  DEFAULT_REMOVEBG_MODEL,
+  REMOVEBG_OUTPUT_TYPE_OPTIONS,
+  DEFAULT_REMOVEBG_OUTPUT_TYPE,
+  REMOVEBG_FORMAT_OPTIONS,
+  DEFAULT_REMOVEBG_FORMAT,
+  REMOVEBG_SCALE_OPTIONS,
+  DEFAULT_REMOVEBG_SCALE,
+  REMOVEBG_SHADOW_OPTIONS,
+  DEFAULT_REMOVEBG_SHADOW,
+  REMOVEBG_SHADOW_DISABLED,
+  REMOVEBG_SHADOW_CUSTOM,
+  REMOVEBG_OUTPUT_TYPE_CUTOUT,
+  DEFAULT_REMOVEBG_BG_BLUR,
+  DEFAULT_REMOVEBG_STROKE_SIZE,
+  DEFAULT_REMOVEBG_STROKE_COLOR,
+  DEFAULT_REMOVEBG_STROKE_OPACITY,
+  DEFAULT_REMOVEBG_SHADOW_OPACITY,
+  DEFAULT_REMOVEBG_SHADOW_BLUR,
+  DEFAULT_REMOVEBG_SHADOW_OFFSET,
+  REMOVEBG_PERCENT_MIN,
+  REMOVEBG_PERCENT_MAX,
+  REMOVEBG_OFFSET_MIN,
+  REMOVEBG_OFFSET_MAX,
+  WIDGET_HEIGHT_WITH_KEY,
+  WIDGET_HEIGHT_REMOVE_BG_ADVANCED,
 } from "@constants/index";
 import {
   Button,
   ImageSelectionBanner,
   LoadingSpinner,
 } from "@components/index";
+import usePluginHeight from "@hooks/usePluginHeight";
 import { BtnType } from "../../types/enums";
+import "./styles.scss";
 
 interface RemoveBackgroundProps {
   gottenKey: string;
@@ -23,6 +52,86 @@ interface RemoveBackgroundProps {
   isOffline: boolean;
 }
 
+interface SelectFieldProps {
+  label: string;
+  value: string;
+  options: readonly (SelectOption | string)[];
+  tabIndex: number;
+  wide?: boolean;
+  onChange: (value: string) => void;
+}
+
+interface NumberFieldProps {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  tabIndex: number;
+  wide?: boolean;
+  onChange: (value: number) => void;
+}
+
+// A plain string list is its own label; SelectOption lists label a value the
+// API expects but no user would recognise (an AIR model URN, "bottom-right").
+const toOption = (option: SelectOption | string): SelectOption =>
+  typeof option === "string" ? { label: option, value: option } : option;
+
+// The browser does not enforce min/max on a typed-in number, and clearing the
+// field yields "", so every value is pinned to the API's accepted range here.
+const clamp = (value: string, min: number, max: number): number => {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return min;
+  return Math.min(max, Math.max(min, parsed));
+};
+
+const SelectField: React.FC<SelectFieldProps> = ({
+  label,
+  value,
+  options,
+  tabIndex,
+  wide,
+  onChange,
+}) => (
+  <div className={`option-group ${wide ? "wide" : ""}`}>
+    <label className="option-label">{label}</label>
+    <select
+      className="option-select"
+      value={value}
+      tabIndex={tabIndex}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      {options.map(toOption).map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  </div>
+);
+
+const NumberField: React.FC<NumberFieldProps> = ({
+  label,
+  value,
+  min,
+  max,
+  tabIndex,
+  wide,
+  onChange,
+}) => (
+  <div className={`option-group ${wide ? "wide" : ""}`}>
+    <label className="option-label">{label}</label>
+    <input
+      className="option-input"
+      type="number"
+      min={min}
+      max={max}
+      value={value}
+      tabIndex={tabIndex}
+      onChange={(e) => onChange(clamp(e.target.value, min, max))}
+    />
+  </div>
+);
+
 const RemoveBackground: React.FC<RemoveBackgroundProps> = ({
   gottenKey,
   imageBytes,
@@ -31,6 +140,32 @@ const RemoveBackground: React.FC<RemoveBackgroundProps> = ({
   isOffline,
 }) => {
   const [loading, setLoading] = useState<boolean>(false);
+  const [showAdvancedSettings, setShowAdvancedSettings] = useState<boolean>(false);
+
+  const [model, setModel] = useState<string>(DEFAULT_REMOVEBG_MODEL);
+  const [outputType, setOutputType] = useState<string>(DEFAULT_REMOVEBG_OUTPUT_TYPE);
+  const [format, setFormat] = useState<string>(DEFAULT_REMOVEBG_FORMAT);
+  const [scale, setScale] = useState<string>(DEFAULT_REMOVEBG_SCALE);
+  const [autoCenter, setAutoCenter] = useState<boolean>(false);
+  const [bgColor, setBgColor] = useState<string>("");
+  const [bgBlur, setBgBlur] = useState<number>(DEFAULT_REMOVEBG_BG_BLUR);
+  const [strokeSize, setStrokeSize] = useState<number>(DEFAULT_REMOVEBG_STROKE_SIZE);
+  const [strokeColor, setStrokeColor] = useState<string>(DEFAULT_REMOVEBG_STROKE_COLOR);
+  const [strokeOpacity, setStrokeOpacity] = useState<number>(DEFAULT_REMOVEBG_STROKE_OPACITY);
+  const [shadow, setShadow] = useState<string>(DEFAULT_REMOVEBG_SHADOW);
+  const [shadowOpacity, setShadowOpacity] = useState<number>(DEFAULT_REMOVEBG_SHADOW_OPACITY);
+  const [shadowBlur, setShadowBlur] = useState<number>(DEFAULT_REMOVEBG_SHADOW_BLUR);
+  const [shadowOffsetX, setShadowOffsetX] = useState<number>(DEFAULT_REMOVEBG_SHADOW_OFFSET);
+  const [shadowOffsetY, setShadowOffsetY] = useState<number>(DEFAULT_REMOVEBG_SHADOW_OFFSET);
+
+  // A mask is a black-and-white matte: background, stroke and shadow options
+  // have nothing to apply to, so they are neither shown nor sent.
+  const isCutout = outputType === REMOVEBG_OUTPUT_TYPE_CUTOUT;
+
+  usePluginHeight(
+    showAdvancedSettings ? WIDGET_HEIGHT_REMOVE_BG_ADVANCED : WIDGET_HEIGHT_WITH_KEY
+  );
+
   const processImage = async () => {
     if (
       !imageBytes ||
@@ -43,7 +178,23 @@ const RemoveBackground: React.FC<RemoveBackgroundProps> = ({
     setLoading(true);
     sendMessageToSandBox(true, PROCESSING_IMAGE, TYPE_NOTIFY);
 
-    const response = await removeBackgroundApi(imageBytes, gottenKey);
+    const response = await removeBackgroundApi(imageBytes, gottenKey, {
+      model,
+      output_type: outputType,
+      format,
+      scale: isCutout ? scale : undefined,
+      auto_center: isCutout && autoCenter,
+      bg_color: isCutout ? bgColor.trim() || undefined : undefined,
+      bg_blur: isCutout ? bgBlur : undefined,
+      stroke_size: isCutout ? strokeSize : undefined,
+      stroke_color: strokeColor,
+      stroke_opacity: strokeOpacity,
+      shadow: isCutout ? shadow : undefined,
+      shadow_opacity: shadowOpacity,
+      shadow_blur: shadowBlur,
+      shadow_offset_x: shadowOffsetX,
+      shadow_offset_y: shadowOffsetY,
+    });
     if (!response.success) {
       sendMessageToSandBox(false, REMOVE_BG_FAILED_ERR, TYPE_NOTIFY);
       setLoading(false);
@@ -82,15 +233,187 @@ const RemoveBackground: React.FC<RemoveBackgroundProps> = ({
   }
 
   return (
-    <div
-      style={{
-        marginBottom: "75px",
-      }}
-    >
+    <div className="removebg-container">
       <ImageSelectionBanner
         isImageSelected={imageBytes && imageBytes.length > 0}
       />
-      <Button type={btnTpe} cb={cb} tabIndex={8} />
+
+      <div className="advanced-settings">
+        <label
+          className="settings-toggle"
+          tabIndex={8}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              setShowAdvancedSettings(!showAdvancedSettings);
+            }
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={showAdvancedSettings}
+            onChange={(e) => setShowAdvancedSettings(e.target.checked)}
+            tabIndex={-1}
+          />
+          <span className="toggle-switch"></span>
+          <span className="toggle-label">Advanced settings</span>
+        </label>
+
+        {showAdvancedSettings && (
+          <div className="removebg-advanced-options">
+            <SelectField
+              label="Model"
+              value={model}
+              options={REMOVEBG_MODEL_OPTIONS}
+              tabIndex={9}
+              wide
+              onChange={setModel}
+            />
+            <SelectField
+              label="Output type"
+              value={outputType}
+              options={REMOVEBG_OUTPUT_TYPE_OPTIONS}
+              tabIndex={10}
+              onChange={setOutputType}
+            />
+            <SelectField
+              label="Format"
+              value={format}
+              options={REMOVEBG_FORMAT_OPTIONS}
+              tabIndex={11}
+              onChange={setFormat}
+            />
+
+            {isCutout && (
+              <>
+                <SelectField
+                  label="Scale"
+                  value={scale}
+                  options={REMOVEBG_SCALE_OPTIONS}
+                  tabIndex={12}
+                  onChange={setScale}
+                />
+                <NumberField
+                  label="Background blur"
+                  value={bgBlur}
+                  min={REMOVEBG_PERCENT_MIN}
+                  max={REMOVEBG_PERCENT_MAX}
+                  tabIndex={13}
+                  onChange={setBgBlur}
+                />
+
+                <div className="option-group wide">
+                  <label className="option-label">Background color</label>
+                  <input
+                    className="option-input"
+                    type="text"
+                    value={bgColor}
+                    tabIndex={14}
+                    onChange={(e) => setBgColor(e.target.value)}
+                    placeholder="e.g. #82d5fa or blue (optional)"
+                  />
+                </div>
+
+                <label className="option-checkbox wide">
+                  <input
+                    type="checkbox"
+                    checked={autoCenter}
+                    tabIndex={15}
+                    onChange={(e) => setAutoCenter(e.target.checked)}
+                  />
+                  <span>Auto-center subject</span>
+                </label>
+
+                <NumberField
+                  label="Stroke size"
+                  value={strokeSize}
+                  min={REMOVEBG_PERCENT_MIN}
+                  max={REMOVEBG_PERCENT_MAX}
+                  tabIndex={16}
+                  onChange={setStrokeSize}
+                />
+
+                {strokeSize > 0 && (
+                  <>
+                    <div className="option-group">
+                      <label className="option-label">Stroke color</label>
+                      <input
+                        className="option-input"
+                        type="text"
+                        value={strokeColor}
+                        tabIndex={17}
+                        onChange={(e) => setStrokeColor(e.target.value)}
+                        placeholder="e.g. FFFFFF"
+                      />
+                    </div>
+                    <NumberField
+                      label="Stroke opacity"
+                      value={strokeOpacity}
+                      min={REMOVEBG_PERCENT_MIN}
+                      max={REMOVEBG_PERCENT_MAX}
+                      tabIndex={18}
+                      onChange={setStrokeOpacity}
+                    />
+                  </>
+                )}
+
+                <SelectField
+                  label="Shadow"
+                  value={shadow}
+                  options={REMOVEBG_SHADOW_OPTIONS}
+                  tabIndex={19}
+                  wide
+                  onChange={setShadow}
+                />
+
+                {shadow !== REMOVEBG_SHADOW_DISABLED && (
+                  <>
+                    <NumberField
+                      label="Shadow opacity"
+                      value={shadowOpacity}
+                      min={REMOVEBG_PERCENT_MIN}
+                      max={REMOVEBG_PERCENT_MAX}
+                      tabIndex={20}
+                      onChange={setShadowOpacity}
+                    />
+                    <NumberField
+                      label="Shadow blur"
+                      value={shadowBlur}
+                      min={REMOVEBG_PERCENT_MIN}
+                      max={REMOVEBG_PERCENT_MAX}
+                      tabIndex={21}
+                      onChange={setShadowBlur}
+                    />
+                  </>
+                )}
+
+                {shadow === REMOVEBG_SHADOW_CUSTOM && (
+                  <>
+                    <NumberField
+                      label="Shadow offset X"
+                      value={shadowOffsetX}
+                      min={REMOVEBG_OFFSET_MIN}
+                      max={REMOVEBG_OFFSET_MAX}
+                      tabIndex={22}
+                      onChange={setShadowOffsetX}
+                    />
+                    <NumberField
+                      label="Shadow offset Y"
+                      value={shadowOffsetY}
+                      min={REMOVEBG_OFFSET_MIN}
+                      max={REMOVEBG_OFFSET_MAX}
+                      tabIndex={23}
+                      onChange={setShadowOffsetY}
+                    />
+                  </>
+                )}
+              </>
+            )}
+          </div>
+        )}
+      </div>
+
+      <Button type={btnTpe} cb={cb} tabIndex={24} />
       {loading && <LoadingSpinner />}
     </div>
   );

--- a/src/components/removeBackground/styles.scss
+++ b/src/components/removeBackground/styles.scss
@@ -1,0 +1,115 @@
+// The toggle and .option-group / .option-label / .option-select styles are
+// shared with the generate-image advanced panel and defined there; only what is
+// unique to this panel lives here.
+
+// No bottom spacer: the container sits inside a stretched flex box, so trailing
+// margin renders as nothing but still counts as content height — 75px of it was
+// enough to push the balance banner out of the window.
+.removebg-container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-top: 12px;
+}
+
+// Two columns so the panel stays reachable inside the plugin window; controls
+// that need the full width (or hold long values, like a model URN) opt out.
+.removebg-advanced-options {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  align-items: end;
+
+  .wide {
+    grid-column: 1 / -1;
+  }
+}
+
+.option-input {
+  width: 100%;
+  height: 30px;
+  padding: 0 12px;
+  border: 1px solid #cbcbcb;
+  border-radius: 8px;
+  font-family: "Inter";
+  font-size: 11px;
+  font-weight: 500;
+  background-color: white;
+  box-sizing: border-box;
+
+  &:focus {
+    outline: none;
+    border-color: #5a00ee;
+    box-shadow: 0 0 0 2px rgba(90, 0, 238, 0.2);
+  }
+
+  &::placeholder {
+    color: #9e9e9e;
+  }
+}
+
+.option-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font-family: "Inter";
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.16px;
+
+  input[type="checkbox"] {
+    width: 14px;
+    height: 14px;
+    accent-color: #5a00ee;
+    cursor: pointer;
+  }
+}
+
+.figma-light {
+  .option-input {
+    background-color: white;
+    color: #333333;
+    border-color: #cbcbcb;
+
+    &:focus {
+      border-color: #5a00ee;
+    }
+
+    &::placeholder {
+      color: #9e9e9e;
+    }
+  }
+
+  .option-checkbox {
+    color: #333333;
+
+    input[type="checkbox"] {
+      accent-color: #5a00ee;
+    }
+  }
+}
+
+.figma-dark {
+  .option-input {
+    background-color: #2c2c2c;
+    color: #ffffff;
+    border-color: #4a4a4a;
+
+    &:focus {
+      border-color: #bd99f8;
+    }
+
+    &::placeholder {
+      color: #b2b2b2;
+    }
+  }
+
+  .option-checkbox {
+    color: #ffffff;
+
+    input[type="checkbox"] {
+      accent-color: #bd99f8;
+    }
+  }
+}

--- a/src/components/upscale/Upscale.tsx
+++ b/src/components/upscale/Upscale.tsx
@@ -8,8 +8,13 @@ import {
   TYPE_NOTIFY,
   TYPE_SET_BALANCE,
   UPSCALE_FAILED_ERR,
+  UPSCALE_FORMAT_OPTIONS,
+  DEFAULT_UPSCALE_FORMAT,
+  WIDGET_HEIGHT_UPSCALE_WITH_KEY,
+  WIDGET_HEIGHT_UPSCALE_ADVANCED,
 } from "@constants/index";
 import { Button, LoadingSpinner } from "@components/index";
+import usePluginHeight from "@hooks/usePluginHeight";
 import { BtnType } from "../../types/enums";
 import "./styles.scss";
 
@@ -32,6 +37,12 @@ const Upscale: React.FC<UpscaleProps> = ({
   const [loading, setLoading] = useState<boolean>(false);
 
   const [scaleFactor, setScaleFactor] = useState(2);
+  const [showAdvancedSettings, setShowAdvancedSettings] = useState<boolean>(false);
+  const [format, setFormat] = useState<string>(DEFAULT_UPSCALE_FORMAT);
+
+  usePluginHeight(
+    showAdvancedSettings ? WIDGET_HEIGHT_UPSCALE_ADVANCED : WIDGET_HEIGHT_UPSCALE_WITH_KEY
+  );
 
   const handleSubmit = async () => {
     if (
@@ -47,7 +58,7 @@ const Upscale: React.FC<UpscaleProps> = ({
     if (!scaleFactor) return;
     sendMessageToSandBox(true, PROCESSING_IMAGE, TYPE_NOTIFY);
 
-    const response = await enhanceImage(imageBytes, gottenKey, scaleFactor);
+    const response = await enhanceImage(imageBytes, gottenKey, scaleFactor, format);
     if (!response.success) {
       sendMessageToSandBox(false, UPSCALE_FAILED_ERR, TYPE_NOTIFY);
       setLoading(false);
@@ -100,7 +111,47 @@ const Upscale: React.FC<UpscaleProps> = ({
         <span className="header-text">Choose enhance factor</span>
         <Selector onChange={handleOnChange} options={options} text="2" tabIndex={8} />
       </div>
-      <Button type={btnTpe} cb={cb} tabIndex={9} />
+      <div className="advanced-settings">
+        <label
+          className="settings-toggle"
+          tabIndex={9}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              setShowAdvancedSettings(!showAdvancedSettings);
+            }
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={showAdvancedSettings}
+            onChange={(e) => setShowAdvancedSettings(e.target.checked)}
+            tabIndex={-1}
+          />
+          <span className="toggle-switch"></span>
+          <span className="toggle-label">Advanced settings</span>
+        </label>
+
+        <div className={`advanced-options ${showAdvancedSettings ? "visible" : ""}`}>
+          <div className="option-group">
+            <label className="option-label">Format</label>
+            <select
+              className="option-select"
+              value={format}
+              onChange={(e) => setFormat(e.target.value)}
+              tabIndex={showAdvancedSettings ? 10 : -1}
+            >
+              {UPSCALE_FORMAT_OPTIONS.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      </div>
+
+      <Button type={btnTpe} cb={cb} tabIndex={11} />
       <p className="upscale-text">
         Enhance Factor adjusts the level of improvement, such as image quality
         and resolution

--- a/src/components/upscale/styles.scss
+++ b/src/components/upscale/styles.scss
@@ -1,7 +1,9 @@
 
+// No bottom spacer: trailing margin inside this stretched flex box renders as
+// nothing but still counts as content height, which pushes the balance banner
+// out of the window once the advanced panel is open.
 .upscale-container {
   margin-top: 12px;
-  margin-bottom: 37px;
   display: flex;
   flex-direction: column;
   gap: 12px;

--- a/src/hooks/usePluginHeight.ts
+++ b/src/hooks/usePluginHeight.ts
@@ -1,0 +1,19 @@
+import { useEffect } from "react";
+import { sendMessageToSandBox } from "@api/index";
+import { TYPE_RESIZE } from "@constants/index";
+
+/**
+ * Asks the sandbox to resize the plugin window whenever `height` changes.
+ *
+ * Each tab opens at a fixed height and `#root` does not grow with its content,
+ * so a panel revealed after mount (advanced settings) would be cut off. Tabs
+ * re-run `figma.showUI` with their base height, so nothing needs to undo this
+ * on unmount.
+ */
+const usePluginHeight = (height: number) => {
+  useEffect(() => {
+    sendMessageToSandBox(true, "", TYPE_RESIZE, undefined, { height });
+  }, [height]);
+};
+
+export default usePluginHeight;

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -24,16 +24,24 @@ body {
 
 .main-content {
   flex: 1;
+  /* A flex item defaults to min-height:auto, so without this the content below
+     refuses to shrink and pushes the balance banner past #root's clipped edge
+     instead of scrolling. */
+  min-height: 0;
   display: flex;
   flex-direction: column;
-  height: 105%;
 }
 
 .scrollable-content {
   flex: 1;
+  min-height: 0; /* see .main-content — both links in the chain must yield */
   display: flex;
   flex-direction: column;
-  overflow: hidden; /* No scrolling - everything should fit */
+  /* Everything is meant to fit — tabs grow the window when they reveal an
+     advanced-settings panel — but Figma clamps the window to the available
+     screen height, so scroll rather than cut controls off on short screens. */
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 .bottom-banner {


### PR DESCRIPTION
Every request used hardcoded parameters, so picking a model or an output format was not possible from the plugin at all. Each tool now has an advanced settings panel exposing the parameters its endpoint supports.

- Generate Image: model (29 text2image models) and number of images (1-10).
- Remove Background: model, output type, format, scale, background color and blur and, for cutouts, auto-center, stroke and shadow controls - nested controls render only when their parent option is active.
- Upscale: output format.